### PR TITLE
Support multiple accelerators with one binary

### DIFF
--- a/accel/sel4/sel4-all.c
+++ b/accel/sel4/sel4-all.c
@@ -17,9 +17,13 @@
 #include "hw/pci/pci_bus.h"
 #include "migration/vmstate.h"
 
+#include "hw/arm/virt.h"
+
 #include <stdarg.h>
 #include <sys/ioctl.h>
 #include <sel4/sel4_virt.h>
+
+extern MemMapEntry (*virt_memmap_customize)(const MemMapEntry *base_memmap, int i);
 
 void tii_printf(const char *fmt, ...);
 
@@ -444,6 +448,90 @@ err:
     return rc;
 }
 
+static const int vmid = 1;
+static unsigned long uservm_ram_base;
+static unsigned long uservm_ram_size;
+static unsigned long uservm_pcie_mmio_base;
+static unsigned long uservm_pcie_mmio_size;
+
+static int parse_kernel_bootargs(void)
+{
+    FILE *fp;
+    char buffer[4096];
+    char *s, *arg, *sp;
+    int ret = -1;
+    int id;
+
+    if ((fp = fopen("/proc/cmdline", "r")) == NULL) {
+        goto out;
+    }
+    if (fgets(buffer, sizeof buffer, fp) == NULL) {
+        goto close_fp;
+    }
+
+    for (s = buffer; (arg = strtok_r(s, " \t\n", &sp)) != NULL; s = NULL) {
+        if (strncmp(arg, "uservm=", 7)) {
+            continue;
+        }
+        if (sscanf(arg + 7, "%d,%lx,%lx,%lx,%lx",
+            &id,
+            &uservm_ram_base,
+            &uservm_ram_size,
+            &uservm_pcie_mmio_base,
+            &uservm_pcie_mmio_size) != 5) {
+            fprintf(stderr, "Improper %s in bootargs\n", arg);
+            goto close_fp;
+        }
+        if (id == vmid) {
+            ret = 0;
+            break;
+        }
+    }
+
+close_fp:
+    fclose(fp);
+
+out:
+    return ret;
+}
+
+static MemMapEntry sel4_memmap_customize(const MemMapEntry *base_memmap, int i)
+{
+    static bool init = false;
+    MemMapEntry e;
+
+    if (!init) {
+        if (parse_kernel_bootargs()) {
+            fprintf(stderr, "No uservm details given in kernel bootargs\n");
+            exit(1);
+        }
+        init = true;
+    }
+
+    switch (i) {
+    case VIRT_MEM:
+        e.base = uservm_ram_base;
+        e.size = uservm_ram_size;
+        break;
+    case VIRT_PCIE_MMIO:
+        e.base = uservm_pcie_mmio_base;
+        e.size = uservm_pcie_mmio_size;
+        break;
+    case VIRT_PCIE_PIO:
+        e.base = uservm_pcie_mmio_base + uservm_pcie_mmio_size;
+        e.size = 0x10000;
+        break;
+    case VIRT_PCIE_ECAM:
+        e.base = uservm_pcie_mmio_base + uservm_pcie_mmio_size + 0x10000;
+        e.size = 0x1000000;
+        break;
+    default:
+        return base_memmap[i];
+    };
+
+    return e;
+}
+
 static void sel4_accel_class_init(ObjectClass *oc, void *data)
 {
     AccelClass *ac = ACCEL_CLASS(oc);
@@ -452,6 +540,8 @@ static void sel4_accel_class_init(ObjectClass *oc, void *data)
     ac->init_machine = sel4_init;
     ac->setup_post = sel4_setup_post;
     ac->allowed = &sel4_allowed;
+
+    virt_memmap_customize = sel4_memmap_customize;
 }
 
 static void sel4_accel_instance_init(Object *obj)

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -1688,6 +1688,14 @@ static uint64_t virt_cpu_mp_affinity(VirtMachineState *vms, int idx)
     return arm_cpu_mp_affinity(idx, clustersz);
 }
 
+static MemMapEntry noop_memmap_customize(const MemMapEntry *base_memmap, int i)
+{
+    return base_memmap[i];
+}
+
+MemMapEntry (*virt_memmap_customize)(const MemMapEntry *base_memmap, int i) =
+    noop_memmap_customize;
+
 static void virt_set_memmap(VirtMachineState *vms, int pa_bits)
 {
     MachineState *ms = MACHINE(vms);
@@ -1697,7 +1705,7 @@ static void virt_set_memmap(VirtMachineState *vms, int pa_bits)
     vms->memmap = extended_memmap;
 
     for (i = 0; i < ARRAY_SIZE(base_memmap); i++) {
-        vms->memmap[i] = base_memmap[i];
+        vms->memmap[i] = virt_memmap_customize(base_memmap, i);
     }
 
     if (ms->ram_slots > ACPI_MAX_RAM_SLOTS) {

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -158,11 +158,11 @@ static const MemMapEntry base_memmap[] = {
     /* ...repeating for a total of NUM_VIRTIO_TRANSPORTS, each of that size */
     [VIRT_PLATFORM_BUS] =       { 0x0c000000, 0x02000000 },
     [VIRT_SECURE_MEM] =         { 0x0e000000, 0x01000000 },
-    [VIRT_PCIE_MMIO] =          { 0x60000000, 0x7eff0000 },
+    [VIRT_PCIE_MMIO] =          { 0x10000000, 0x2eff0000 },
     [VIRT_PCIE_PIO] =           { 0x3eff0000, 0x00010000 },
     [VIRT_PCIE_ECAM] =          { 0x3f000000, 0x01000000 },
     /* Actual RAM size depends on initial RAM and device memory settings */
-    [VIRT_MEM] =                { 0x48000000, 0x10000000 },
+    [VIRT_MEM] =                { GiB, LEGACY_RAMLIMIT_BYTES },
 };
 
 /*


### PR DESCRIPTION
We have had modifications to `virt` machine memory map -- this PR enables modifications only for the seL4 accelerator. Two additional seL4 related hooks are also omitted on other accelerators (Xen, KVM...).

Also in case of seL4, don't hardcode anything but read virtio frontend buffer address and size (so far the same as uservm guest RAM but for SWIOTLB this is like 8 MB buffer somewhere and guest RAM is allocated from untypeds) from `/proc/cmdline`. It _should_ be read from device tree and/or with `ioctl` from `/dev/sel4` but that's another task.

One might ask how about the reduced feature set in QEMU's BitBake recipe? Well, for KVM/seL4 benchmarking purposes we specifically don't want either one to have more features than the other, so for that we don't need to do anything.