### PR TITLE
sel4: Add interrupt controller

### DIFF
--- a/accel/sel4/sel4-all.c
+++ b/accel/sel4/sel4-all.c
@@ -33,6 +33,7 @@ void tii_printf(const char *fmt, ...);
 static int vmid = 1;
 static MemoryRegion ram_mr;
 bool sel4_allowed;
+bool sel4_ext_vpci_bus;
 
 void sel4_register_pci_device(PCIDevice *d);
 
@@ -392,6 +393,8 @@ static int sel4_init(MachineState *ms)
     s->mem_listener.region_del = sel4_region_del;
 
     memory_listener_register(&s->mem_listener, &address_space_memory);
+
+    sel4_ext_vpci_bus = true;
 
     qemu_add_vm_change_state_handler(sel4_change_state_handler, s);
 

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -844,7 +844,10 @@ static void create_sel4_intc(VirtMachineState *vms)
     sysbus_realize_and_unref(SYS_BUS_DEVICE(vms->gic), &error_fatal);
 
     fdt_add_gic_node(vms);
-    create_v2m(vms);
+
+    if (!sel4_ext_vpci_bus_enabled()) {
+        create_v2m(vms);
+    }
 }
 
 static void create_uart(const VirtMachineState *vms, int uart,
@@ -1427,6 +1430,12 @@ static void create_pcie(VirtMachineState *vms)
     MachineState *ms = MACHINE(vms);
 
     dev = qdev_new(TYPE_GPEX_HOST);
+
+    // FIXME: hackery
+    if (sel4_ext_vpci_bus_enabled()) {
+        qdev_prop_set_uint32(dev, "num-irqs", SEL4_VPCI_INTERRUPTS);
+    }
+
     sysbus_realize_and_unref(SYS_BUS_DEVICE(dev), &error_fatal);
 
     ecam_id = VIRT_ECAM_ID(vms->highmem_ecam);
@@ -1464,10 +1473,20 @@ static void create_pcie(VirtMachineState *vms)
     /* Map IO port space */
     sysbus_mmio_map(SYS_BUS_DEVICE(dev), 2, base_pio);
 
-    for (i = 0; i < GPEX_NUM_IRQS; i++) {
+    /* FIXME: hackery */
+    if (sel4_ext_vpci_bus_enabled()) {
+        irq = NUM_IRQS;
+    }
+
+    for (i = 0; i < GPEX_HOST(dev)->num_irqs; i++) {
         sysbus_connect_irq(SYS_BUS_DEVICE(dev), i,
                            qdev_get_gpio_in(vms->gic, irq + i));
         gpex_set_irq_num(GPEX_HOST(dev), i, irq + i);
+    }
+
+    /* FIXME: hackery */
+    if (sel4_ext_vpci_bus_enabled()) {
+        irq = vms->irqmap[VIRT_PCIE];
     }
 
     pci = PCI_HOST_BRIDGE(dev);

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -49,6 +49,7 @@
 #include "sysemu/tpm.h"
 #include "sysemu/kvm.h"
 #include "sysemu/hvf.h"
+#include "sysemu/sel4.h"
 #include "hw/loader.h"
 #include "qapi/error.h"
 #include "qemu/bitops.h"
@@ -834,6 +835,16 @@ static void create_gic(VirtMachineState *vms, MemoryRegion *mem)
     } else if (vms->gic_version == VIRT_GIC_VERSION_2) {
         create_v2m(vms);
     }
+}
+
+static void create_sel4_intc(VirtMachineState *vms)
+{
+    vms->gic = qdev_new("sel4-intc");
+    qdev_prop_set_uint32(vms->gic, "num-irqs", NUM_IRQS);
+    sysbus_realize_and_unref(SYS_BUS_DEVICE(vms->gic), &error_fatal);
+
+    fdt_add_gic_node(vms);
+    create_v2m(vms);
 }
 
 static void create_uart(const VirtMachineState *vms, int uart,
@@ -2222,7 +2233,11 @@ static void machvirt_init(MachineState *machine)
 
     virt_flash_fdt(vms, sysmem, secure_sysmem ?: sysmem);
 
-    create_gic(vms, sysmem);
+    if (!sel4_enabled()) {
+        create_gic(vms, sysmem);
+    } else {
+        create_sel4_intc(vms);
+    }
 
     virt_cpu_post_init(vms, sysmem);
 

--- a/hw/intc/meson.build
+++ b/hw/intc/meson.build
@@ -31,6 +31,7 @@ specific_ss.add(when: 'CONFIG_ARM_GIC', if_true: files('arm_gicv3_cpuif_common.c
 specific_ss.add(when: 'CONFIG_ARM_GICV3_TCG', if_true: files('arm_gicv3_cpuif.c'))
 specific_ss.add(when: 'CONFIG_ARM_GIC_KVM', if_true: files('arm_gic_kvm.c'))
 specific_ss.add(when: ['CONFIG_ARM_GIC_KVM', 'TARGET_AARCH64'], if_true: files('arm_gicv3_kvm.c', 'arm_gicv3_its_kvm.c'))
+specific_ss.add(when: 'CONFIG_SEL4', if_true: files('sel4_intc.c'))
 specific_ss.add(when: 'CONFIG_ARM_V7M', if_true: files('armv7m_nvic.c'))
 specific_ss.add(when: 'CONFIG_ASPEED_SOC', if_true: files('aspeed_vic.c'))
 specific_ss.add(when: 'CONFIG_EXYNOS4', if_true: files('exynos4210_gic.c', 'exynos4210_combiner.c'))

--- a/hw/intc/sel4_intc.c
+++ b/hw/intc/sel4_intc.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "qemu/osdep.h"
+#include "qapi/error.h"
+#include "qemu/module.h"
+#include "qom/object.h"
+#include "hw/sysbus.h"
+#include "qemu/log.h"
+#include "hw/qdev-properties.h"
+#include "gic_internal.h"
+#include "sysemu/sel4.h"
+
+#define TYPE_SEL4_INTC "sel4-intc"
+OBJECT_DECLARE_SIMPLE_TYPE(SeL4IntcState, SEL4_INTC)
+
+struct SeL4IntcState {
+    SysBusDevice parent_obj;
+
+    /* Number of external interrupts */
+    uint32_t num_irqs;
+};
+typedef struct SeL4IntcState SeL4IntcState;
+
+static void sel4_intc_set_irq(void *opaque, int irq, int level)
+{
+    SeL4IntcState *s = opaque;
+
+    /* Using following irq encoding for easier integration to arm-virt. The
+     * encoding is similar to arm-gic-kvm:
+     *  [0..N-1]: SPIs on emulated devices
+     *  [N..N+31]: Devices attached to seL4 vPCI
+     *
+     * On GIC 0-31 is reserved for SGIs and PPIs, but we use that region for
+     * seL4 vPCI interrupts. External interrupts (=non-seL4 vPCI
+     * devices) are mapped 1:1 to SPIs.
+     */
+    if (irq < s->num_irqs) {
+        sel4_set_irq(irq + SEL4_VPCI_INTERRUPTS, !!level);
+    } else {
+        int vpci_irq = irq - s->num_irqs;
+        if (vpci_irq < 0 || vpci_irq >= SEL4_VPCI_INTERRUPTS) {
+            qemu_log_mask(LOG_GUEST_ERROR, "sel4_intc: failed to translate"
+                          "interrupt (%d) to vpci interrupt range (%d)\n",
+                          irq, vpci_irq);
+            return;
+        }
+        sel4_set_irq(vpci_irq, !!level);
+    }
+}
+
+static void sel4_intc_realize(DeviceState *dev, Error **errp)
+{
+    SeL4IntcState *s = SEL4_INTC(dev);
+
+    if (s->num_irqs > GIC_MAXIRQ) {
+        error_setg(errp,
+                   "requested %u interrupt lines exceeds GIC maximum %d",
+                   s->num_irqs, GIC_MAXIRQ);
+        return;
+    }
+
+    qdev_init_gpio_in(dev, sel4_intc_set_irq, SEL4_VPCI_INTERRUPTS + s->num_irqs);
+}
+
+static Property sel4_intc_props[] = {
+    DEFINE_PROP_UINT32("num-irqs", SeL4IntcState, num_irqs, 192),
+    DEFINE_PROP_END_OF_LIST(),
+};
+
+static void sel4_intc_class_init(ObjectClass *klass, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+
+    device_class_set_props(dc, sel4_intc_props);
+
+    dc->realize = sel4_intc_realize;
+}
+
+static const TypeInfo sel4_intc_info = {
+    .name = TYPE_SEL4_INTC,
+    .parent = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(SeL4IntcState),
+    .class_init = sel4_intc_class_init,
+};
+
+static void sel4_intc_register_types(void)
+{
+    type_register_static(&sel4_intc_info);
+}
+
+type_init(sel4_intc_register_types)

--- a/hw/pci-host/gpex.c
+++ b/hw/pci-host/gpex.c
@@ -41,13 +41,9 @@
  * GPEX host
  */
 
-void sel4_set_irq(unsigned int irq, bool);
-
 static void gpex_set_irq(void *opaque, int irq_num, int level)
 {
     GPEXHost *s = opaque;
-
-    sel4_set_irq(irq_num, !!level);
 
     qemu_set_irq(s->irq[irq_num], level);
 }

--- a/include/hw/pci-host/gpex.h
+++ b/include/hw/pci-host/gpex.h
@@ -51,8 +51,9 @@ struct GPEXHost {
     MemoryRegion io_mmio;
     MemoryRegion io_ioport_window;
     MemoryRegion io_mmio_window;
-    qemu_irq irq[GPEX_NUM_IRQS];
-    int irq_num[GPEX_NUM_IRQS];
+    qemu_irq *irq;
+    int *irq_num;
+    uint32_t num_irqs;
 
     bool allow_unmapped_accesses;
 };

--- a/include/sysemu/sel4.h
+++ b/include/sysemu/sel4.h
@@ -21,15 +21,18 @@
 #ifdef CONFIG_SEL4_IS_POSSIBLE
 
 extern bool sel4_allowed;
+extern bool sel4_ext_vpci_bus;
 
-#define sel4_enabled()           (sel4_allowed)
-
-void sel4_set_irq(unsigned int irq, bool);
+#define sel4_enabled()              (sel4_allowed)
+#define sel4_ext_vpci_bus_enabled() (sel4_ext_vpci_bus)
 
 #else /* !CONFIG_SEL4_IS_POSSIBLE */
 
-#define sel4_enabled() 0
+#define sel4_enabled()              (false)
+#define sel4_ext_vpci_bus_enabled() (false)
 
 #endif /* CONFIG_SEL4_IS_POSSIBLE */
+
+void sel4_set_irq(unsigned int irq, bool);
 
 #endif

--- a/include/sysemu/sel4.h
+++ b/include/sysemu/sel4.h
@@ -1,0 +1,35 @@
+/*
+ * QEMU seL4 support
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#ifndef SYSEMU_SEL4_H
+#define SYSEMU_SEL4_H
+
+#ifdef NEED_CPU_H
+# ifdef CONFIG_SEL4
+#  define CONFIG_SEL4_IS_POSSIBLE
+# endif
+#else
+# define CONFIG_SEL4_IS_POSSIBLE
+#endif
+
+#define SEL4_VPCI_INTERRUPTS (32)
+
+#ifdef CONFIG_SEL4_IS_POSSIBLE
+
+extern bool sel4_allowed;
+
+#define sel4_enabled()           (sel4_allowed)
+
+void sel4_set_irq(unsigned int irq, bool);
+
+#else /* !CONFIG_SEL4_IS_POSSIBLE */
+
+#define sel4_enabled() 0
+
+#endif /* CONFIG_SEL4_IS_POSSIBLE */
+
+#endif


### PR DESCRIPTION
Add virtual interrupt controller for seL4. The interrupt controller allows interrupts to go through qemu APIs.

Also include a temporary fix for vPCI interrupt routing. 